### PR TITLE
Vagrant Provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Desktop.ini
 
 # Generated Project Files
 premake/*/
+bin/*
 
 # Vagrant
 .vagrant/

--- a/README.md
+++ b/README.md
@@ -40,16 +40,15 @@ When following instructions below, the compiled binary will be output in the bin
 
 ### Using Vagrant
 
-    # Launch VM
+    # Launch VM and build
     vagrant up
+
+    # Patch VM and re-build
+    vagrant provision
+
+    # Manual build
     vagrant ssh
-    cd /vagrant
-
-    # Install Linux dependencies (first time setup)
-    ./vagrant.sh
-
-    # Build demboyz
-    cd premake
+    cd /vagrant/premake
     ./gmake.sh && cd gmake
     make
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,4 +119,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # chef-validator, unless you changed the configuration.
   #
   #   chef.validation_client_name = "ORGNAME-validator"
+
+  # Shell provisioner
+  config.vm.provision "shell", path: "vagrant.sh"
 end

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # http://askubuntu.com/a/497033
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -20,8 +20,9 @@ packages="$packages clang-3.6++"
 sudo apt-get install -y $packages
 
 # Why doesn't clang do this for us?
-[ ! -e /usr/bin/clang++ ] && sudo ln -s /usr/bin/clang++-3.6 /usr/bin/clang++
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 10
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 10
 
 # Build it!
 cd /vagrant/premake
-/bin/bash gmake.sh && { cd gmake; make; }
+./gmake.sh && { cd gmake; make; }

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -4,10 +4,24 @@
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update
 
-sudo apt-get install build-essential -y
+# Remove X11 cruft
+sudo apt-get autoremove -y
 
-sudo apt-get install gcc-4.9 g++-4.9 -y
-sudo apt-get install gcc-4.9-multilib g++-4.9-multilib -y
+# Keep things up to date
+sudo apt-get upgrade -y
 
-sudo apt-get install clang-3.6++ -y
-sudo ln -s /usr/bin/clang++-3.6 /usr/bin/clang++
+packages=""; # Start with nothing; can re-order rest to heart's content
+
+packages="$packages build-essential"
+packages="$packages gcc-4.9 g++-4.9"
+packages="$packages gcc-4.9-multilib g++-4.9-multilib"
+packages="$packages clang-3.6++"
+
+sudo apt-get install -y $packages
+
+# Why doesn't clang do this for us?
+[ ! -e /usr/bin/clang++ ] && sudo ln -s /usr/bin/clang++-3.6 /usr/bin/clang++
+
+# Build it!
+cd /vagrant/premake
+/bin/bash gmake.sh && { cd gmake; make; }


### PR DESCRIPTION
This adds provisioning for the Vagrant box, so a "vagrant up" installs all the tools, and builds demboyz.

Allows for "vagrant provision" to keep things up to date