### PR TITLE
Updated Vagrant to install g++ dependencies

### DIFF
--- a/vagrant.sh
+++ b/vagrant.sh
@@ -1,27 +1,11 @@
 #!/bin/sh
 
-# http://askubuntu.com/a/497033
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-sudo apt-get update
-
-# Remove X11 cruft
-sudo apt-get autoremove -y
-
 # Keep things up to date
+sudo apt-get update
 sudo apt-get upgrade -y
 
-packages=""; # Start with nothing; can re-order rest to heart's content
-
-packages="$packages build-essential"
-packages="$packages gcc-4.9 g++-4.9"
-packages="$packages gcc-4.9-multilib g++-4.9-multilib"
-packages="$packages clang-3.6++"
-
-sudo apt-get install -y $packages
-
-# Why doesn't clang do this for us?
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 10
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 10
+# Install g++ dependencies 
+sudo apt-get install -y build-essential g++-4.8 g++-4.8-multilib
 
 # Build it!
 cd /vagrant/premake


### PR DESCRIPTION
In reference to Issue #6:
Added packages for Vagrant to install which compilation requires (namely `g++-4.8-multilib`)