### PR TITLE
Increase MAX_PLAYERS to prevent assert being thrown when more than 32…

### DIFF
--- a/demboyz/io/voicewriter/voicedatawriter.cpp
+++ b/demboyz/io/voicewriter/voicedatawriter.cpp
@@ -13,7 +13,7 @@
 
 #include "ivoicecodecmanager.h"
 
-#define MAX_PLAYERS 33
+#define MAX_PLAYERS 65
 
 class VoiceDataWriter: public IDemoWriter
 {

--- a/demboyz/io/voicewriter/voicedatawriter.cpp
+++ b/demboyz/io/voicewriter/voicedatawriter.cpp
@@ -13,11 +13,7 @@
 
 #include "ivoicecodecmanager.h"
 
-<<<<<<< HEAD
 #define MAX_PLAYERS 65
-=======
-#define MAX_PLAYERS 255
->>>>>>> bbf0775072cbd7ce6dfb245daff350235ffcff20
 
 class VoiceDataWriter: public IDemoWriter
 {


### PR DESCRIPTION
… players

- Player value is greater than 32 or when they join/reconnect
- Comparison is uint8_t. Increasing this size should not affect the memory as much

## Issue
In `voicedatawriter.cpp`, the MAX_PLAYERS can throw an error if there were more than 64 players or if those players left and rejoined the server. I am parsing through the GFLClan CS:S ZE Demos and had this assert statement thrown at me multiple times for having 64 players or people reconnecting. You can test this by downloading `auto-20231001-002351-ze_ffxiv_wanderers_palace_v6css.dem.bz2` on https://demos.2qt.eu/css-ze/